### PR TITLE
フルでタイトルを返すヘルパー関数の追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,13 @@
 module ApplicationHelper
+
+    # タイトルヘルパ＝
+    def full_title(page_title = "")
+        base_title = "Ruby on Rails Tutorial Sample App"
+        if page_title.empty?
+            base_title
+        else
+            page_title + " | " + base_title
+        end
+    end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag    'application', media: 'all',
                                'data-turbolinks-track': 'reload' %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,3 @@
-<% provide(:title, "Home") %>
 <h1>Sample App</h1>
 <p>
   This is the home page for the

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -8,13 +8,13 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test "should get root" do
     get root_url
     assert_response :success
-    assert_select "title", "Home | #{ @base_title }"
+    assert_select "title", "#{ @base_title }"
   end
 
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home | #{ @base_title }"
+    assert_select "title", "#{ @base_title }"
   end
 
   test "should get help" do


### PR DESCRIPTION
# 復習
- Ruby（Rails）独特の記法はやっぱり慣れが必要だなと思った反面，よくよく見返すとGoのインタプリタで使われてた組み込み関数名などはRubyのものだったんだとわかった．