### PR TITLE
セッションを使ったログイン機構

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,7 @@
 // about supported directives.
 //
 //= require rails-ujs
+//= require jquery
+//= require bootstrap
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/sessions.coffee
+++ b/app/assets/javascripts/sessions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  include SessionsHelper
 
   def hello
     render html: "Hello, World!"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,5 +16,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    log_out
+    redirect_to root_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,18 @@
 class SessionsController < ApplicationController
   def new
   end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user && user.authenticate(params[:session][:password])
+      # ユーザーログイン後にユーザー情報のページにリダイレクトする
+    else
+      # エラーメッセージを作成する
+      flash.now[:danger] = 'Invalid email/password combination'
+      render 'new'
+    end
+  end
+
+  def destroy
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,8 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
+      log_in user
+      redirect_to user # = redirect_to user_url(user)
     else
       # エラーメッセージを作成する
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      log_in @user
       flash[:success] = "Welcome to the Sample App!"
       redirect_to @user
     else

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,4 +17,10 @@ module SessionsHelper
   def logged_in?
     !current_user.nil?
   end
+
+  # 現在のユーザーをログアウトする
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,4 +12,9 @@ module SessionsHelper
       @current_user ||= User.find_by(id: session[:user_id])
     end
   end
+
+  # ユーザーがログインしていればtrue、その他ならfalseを返す
+  def logged_in?
+    !current_user.nil?
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,2 +1,15 @@
 module SessionsHelper
+
+  # 渡されたユーザーでログインする
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def current_user
+    # session[:user_id]が存在しないときはnil
+    if session[:user_id]
+      # or equals
+      @current_user ||= User.find_by(id: session[:user_id])
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,11 @@ class User < ApplicationRecord
                       uniqueness: { case_sensitive: false }
     validates :password, presence: true, length: { minimum: 6 }
     has_secure_password
+
+    # 渡された文字列のハッシュ値を返す
+    def User.digest(string)
+    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                  BCrypt::Engine.cost
+    BCrypt::Password.create(string, cost: cost)
+  end
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,3 +6,16 @@
                 %li= link_to "Home",   root_path 
                 %li= link_to "Help",   help_path 
                 %li= link_to "Log in",   '#' 
+                -if logged_in?
+                    %li = link_to "Users", '#'
+                    %li.dropdown
+                        %a{ :href=>"#", :class=>"dropdown-toggle", :data-toggle=>"dropdown" }
+                            Account 
+                            %b.caret
+                        %ul.dropdown-menu
+                            %li= link_to "Profile", current_user
+                            %li= link_to "Settings", "#"
+                            %li.divider
+                            %li= link_to "Log out", logout_path, method: :delete
+                -else
+                    %li= link_to "Log in", login_path

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,0 +1,2 @@
+%h1 Sessions#new
+%p Find me in app/views/sessions/new.html.haml

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,2 +1,16 @@
-%h1 Sessions#new
-%p Find me in app/views/sessions/new.html.haml
+=provide(:title, "Log in")
+%h1 Log in
+.row 
+  .col-md-6.col-md-offset-3
+    =form_for(:session, url: login_path) do |f|
+      =f.label :email
+      =f.email_field  :email, class: 'form-control'
+
+      =f.label :password
+      =f.password_field  :email, class: 'form-control'
+
+      =f.submit "Log in", class: "btn btn-primary"
+
+    %p
+      New user?
+      =link_to "Sign up now!", signup_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get 'sessions/new'
+
   root 'static_pages#home'
   get  '/help',    to: 'static_pages#help'
   get  '/about',   to: 'static_pages#about'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,14 @@
 Rails.application.routes.draw do
 
   root 'static_pages#home'
-  get  '/help',    to: 'static_pages#help'
-  get  '/about',   to: 'static_pages#about'
-  get  '/contact', to: 'static_pages#contact'
-  get  '/signup',  to: 'users#new'
-  post '/signup',  to: 'users#create'
-  get  'login',     to: 'sessions#new'
-  post 'login',    to: 'sessions#create'
-  get  'logout',    to: 'sessions#destroy'
+  get    '/help',    to: 'static_pages#help'
+  get    '/about',   to: 'static_pages#about'
+  get    '/contact', to: 'static_pages#contact'
+  get    '/signup',  to: 'users#new'
+  post   '/signup',  to: 'users#create'
+  get    '/login',   to: 'sessions#new'
+  post   '/login',   to: 'sessions#create'
+  delete '/logout',  to: 'sessions#destroy'
   resources :users
   
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,14 @@
 Rails.application.routes.draw do
 
-  get 'sessions/new'
-
   root 'static_pages#home'
   get  '/help',    to: 'static_pages#help'
   get  '/about',   to: 'static_pages#about'
   get  '/contact', to: 'static_pages#contact'
-  get  '/signup', to: 'users#new'
+  get  '/signup',  to: 'users#new'
   post '/signup',  to: 'users#create'
+  get  'login',     to: 'sessions#new'
+  post 'login',    to: 'sessions#create'
+  get  'logout',    to: 'sessions#destroy'
   resources :users
   
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
-    get sessions_new_url
+    get login_path
     assert_response :success
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get sessions_new_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,1 +1,4 @@
-# 8章で追加
+michael:
+  name: Michael Example
+  email: michael@example.com
+  password_digest: <%= User.digest('password') %>

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class UsersLoginTest < ActionDispatch::IntegrationTest
 
+  def setup
+    @user = users(:michael)
+  end
+
   test "login with invalid information" do
     get login_path
     assert_template 'sessions/new'
@@ -10,5 +14,17 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     get root_path
     assert flash.empty?
+  end
+
+  test "login with valid information" do
+    get login_path
+    post login_path, params: { session: { email:    @user.email,
+                                          password: 'password' } }
+    assert_redirected_to @user
+    follow_redirect!
+    assert_template 'users/show'
+    assert_select "a[href=?]", login_path, count: 0
+    assert_select "a[href=?]", logout_path
+    assert_select "a[href=?]", user_path(@user)
   end
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class UsersLoginTest < ActionDispatch::IntegrationTest
+
+  test "login with invalid information" do
+    get login_path
+    assert_template 'sessions/new'
+    post login_path, params: { session: { email: "", password: "" } }
+    assert_template 'sessions/new'
+    assert_not flash.empty?
+    get root_path
+    assert flash.empty?
+  end
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -27,4 +27,24 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path
     assert_select "a[href=?]", user_path(@user)
   end
+
+  test "login with valid information followed by logout" do
+    get login_path
+    post login_path, params: { session: { email:    @user.email,
+                                          password: 'password' } }
+    assert is_logged_in?
+    assert_redirected_to @user
+    follow_redirect!
+    assert_template 'users/show'
+    assert_select "a[href=?]", login_path, count: 0
+    assert_select "a[href=?]", logout_path
+    assert_select "a[href=?]", user_path(@user)
+    delete logout_path
+    assert_not is_logged_in?
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_select "a[href=?]", login_path
+    assert_select "a[href=?]", logout_path,      count: 0
+    assert_select "a[href=?]", user_path(@user), count: 0
+  end
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -25,6 +25,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     follow_redirect!
     assert_template 'users/show'
-    assert_not flash.empty?
+    assert is_logged_in?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,10 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
   include ApplicationHelper
-
+  
+  # テストユーザーがログイン中の場合にtrueを返す
+  def is_logged_in?
+    !session[:user_id].nil?
+  end
   # Add more helper methods to be used by all tests here...
 end


### PR DESCRIPTION
# What
- セッションの追加による一時的なログインを追加
  - Cookieの中にsessionのIDを保持しておくことで誰がログインしたのかを保持しておく
  - 永続的なCookieではなく一時的なもので，sessionメソッドで実装する．（永続的な方は9章で）
    - セッションやクッキーのメソッドはメソッドだけどもハッシュマップのように扱えるように実装されている．[参考URL](https://qiita.com/zettaittenani/items/a75f0da8f44cfe0f85c0)
 - ログアウト
   - セッションの削除（``session.delete(:user_id)``）とユーザインスタンスを削除

# 復習
- newをログイン，認証を突破したときにはcreateでログイン処理を実行，destroyをログアウトとする．
- Flashについて
  - 通常の書き方（e.g. ``flash[:denger]``）だとリダイレクトなどによるレンダリングが起きないときはフラッシュメッセージが消えない
  - renderで消すときは``flash.now[:denger]``のように書くことで，これを対処できる
- セッションを使ったときのログイン
  - まずemailと入力されたパスワードを用いて認証をかけてpassするとログイン処理
  - ログイン処理というのはセッションID（=ユーザID）をクライアントとサーバー側で一時的に保持（DBには保存しない）することで達成
  - このセッションIDをもとに，emailなどの一意の識別子を用いてユーザを特定し現在のユーザとしてインスタンスを保持しておく
  - その後はこのインスタンス変数を用いて処理を切り替える
- セッションを使ったときのログアウト
  - 単にサーバ側で保持しているsessionを削除することでクライアントの一時的なクッキーからも削除される
 - セッションのより詳細なイメージ
   - sessionを追加した時点でクライアントとサーバ間の通信におけるパラメータにクッキー(expiresの有効期限を指定していない)が送受信される
   - このクッキー値を相互にやり取りすることで識別を行う．
     - 期限がないクッキーはブラウザには保存せずクライアント-サーバー間で毎回送受信するので，ブラウザには保存されない
     - このセッションは暗号化されるとともにブラウザには保存されないのでセッションハイジャックの危険はない

# 所感
改めてこの認証，認可の実装はいい勉強になる．．．（Railsだとここはあらかじめ実装されているので，より詳細な流れが記載された[Qiita記事](https://qiita.com/zettaittenani/items/a75f0da8f44cfe0f85c0)はよりいい勉強になった）